### PR TITLE
feat: add --no-sandbox argument in puppeteer configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ class MonoChrome {
     }
 
     protected async launchBrowser(): Promise<any> {
-        const args = ["--single-process", "--process-per-site"];
+        const args = ["--single-process", "--process-per-site", "--no-sandbox"];
         const opt = {
             headless: !this.debug,
             devtools: this.debug,


### PR DESCRIPTION
## Background

I found error when running testing using puppeteer.

```
Failed to launch chrome!
    [1105/083049.896572:FATAL:zygote_host_impl_linux.cc(116)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

After I check troubleshooting document, suggested to add `--no-sandbox` argument.

See: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox